### PR TITLE
Improve the partial generation

### DIFF
--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -93,7 +93,16 @@ function addLastVersionAsPartial(version, previousReleases, nb) {
     nbAdded=0
     // We always add the last released version to the list
     for (k = 0; k < previousReleases.length; k++) {
+
         previousRelease = stripBuildNumber(previousReleases[k]);
+
+        // In the 38 cycle, we built the 38 beta version from the
+        // mozilla-release branch. We don't want beta partials for a release
+        // This is confusing ship-it (and us)
+        if (isRelease(version) && isBeta(previousRelease)) {
+            continue;
+        }
+
         if (previousRelease < version) {
             partialList += previousReleases[k] + ",";
             nbAdded++;

--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -113,6 +113,7 @@ function getVersionWithBuildNumber(version, previousReleases) {
         }
     }
     console.warn("Could not find the build number of " + version + " from " + previousReleases);
+    return undefined;
 }
 
 
@@ -233,11 +234,16 @@ function populatePartial(name, version, previousBuilds, partialElement) {
         }
         // Build a previous release should not occur but it is the case
         // don't provide past partials
-        partial += getVersionWithBuildNumber(partialsADIVersion[i], previousReleases);
-        partialAdded++;
+        newPartial = getVersionWithBuildNumber(partialsADIVersion[i], previousReleases);
+        if (newPartial != undefined) {
+            // Only add when we found a matching version
+            partial += newPartial;
+            partialAdded++;
+        }
 
         if (i + 1 != partialsADIVersion.length &&
-            partialAdded != nbPartial) {
+            partialAdded != nbPartial &&
+            newPartial != undefined) {
             // We don't want a trailing ","
             partial += ",";
         }

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -188,4 +188,15 @@ var result = populatePartial("firefox", "37.0", previousBuilds, partialElement);
 assert.ok( result );
 assert.strictEqual($('#partials').val(), "36.0.4build2,36.0.3build2,35.0build2,");
 
+// Test the case we had during the 38 cycle (beta built from m-r)
+allPartialJ='{"release": [{"version": "38.0.3", "ADI": 5000}, {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}]}';
+allPartial=JSON.parse(allPartialJ);
+
+previousBuilds = {"releases/mozilla-release": ["38.0.3build2", "38.0b6build2",  "36.0build2", "35.0build2"]}
+
+partialElement = $('#partials');
+var result = populatePartial("firefox", "39.0", previousBuilds, partialElement);
+assert.ok( result );
+assert.strictEqual($('#partials').val(), "38.0.3build2,35.0build2,36.0build2");
+
 });


### PR DESCRIPTION
One patch is to remove the display of "undefined" when the database is inconsistent.
The second is to workaround the 38 beta issue.
A non regression test has been added.
