### PR TITLE
Search filter support added to serverside

### DIFF
--- a/kickoff/model.py
+++ b/kickoff/model.py
@@ -6,7 +6,7 @@ import re
 
 from sqlalchemy import func
 from sqlalchemy.ext.hybrid import hybrid_property
-
+from sqlalchemy.sql.expression import or_
 from mozilla.release.info import getReleaseName
 
 from kickoff import db
@@ -230,7 +230,7 @@ class ReleasesPaginationCriteria:
         self.orderByDict = orderByDict
 
 def getReleases(ready=None, complete=None, status=None, productFilter=None, versionFilter=None,
-                versionFilterCategory=None, searchOtherShipped=False, lastRelease=None, paginationCriteria = None):
+                versionFilterCategory=None, searchOtherShipped=False, lastRelease=None, paginationCriteria = None, searchFilter = None):
 
     filters = {}
     if ready is not None:
@@ -258,6 +258,10 @@ def getReleases(ready=None, complete=None, status=None, productFilter=None, vers
                 qry = table.query.filter_by(**filters).order_by(table._submittedAt.desc()).limit(40)
             else:
                 qry = table.query.filter_by(**filters)
+
+                if searchFilter:
+                    searchList = table.getSearchList(searchFilter)
+                    qry = qry.filter(or_(*searchList))
 
                 if paginationCriteria:
                     if productFilter:
@@ -510,3 +514,17 @@ class ProductReleasesView(Release, db.Model):
     promptWaitTime = db.Column(db.Integer(), nullable=True)
     commRevision = db.Column(db.String(100))
     commRelbranch = db.Column(db.String(50))
+
+    @classmethod
+    def OR(cls, searchList):
+        return or_(*searchList)
+
+    @classmethod
+    def getSearchList(cls, searchDict = {}):
+        lst = []
+        for k, v in searchDict.iteritems():
+            column = getattr(cls, k)
+            contains = getattr(column, 'contains')
+            lst.append(contains(v))
+
+        return lst

--- a/kickoff/static/kickoff.js
+++ b/kickoff/static/kickoff.js
@@ -90,7 +90,7 @@ function viewReleases() {
             {'mData': 'status'},
             {'mData': 'name'},
             {'mData': 'submitter'},
-            {'mData': 'submittedAt'},
+            {'mData': 'submittedAt', 'bSearchable': false},
             {'mData': 'branch'},
             {'mData': 'mozillaRevision'},
             {'mData': 'mozillaRelbranch'},
@@ -158,7 +158,7 @@ function viewReleases() {
             {'mData': 'name'},
             {'mData':  'description'},
             {'mData': 'submitter'},
-            {'mData': 'submittedAt',
+            {'mData': 'submittedAt', 'bSearchable': false,
              'mRender': function(data, type, full) {
                 return '<span style="white-space: nowrap;" class="dateDisplay">' + data + '</span>';
             }},
@@ -179,7 +179,7 @@ function viewReleases() {
             }},
             {'mData': 'promptWaitTime', 'mRender': buildPromptWaitTimeLabel},
             {'mData': 'comment', 'mRender': buildCommentCell},
-            {'mData': 'shippedAt',
+            {'mData': 'shippedAt', 'bSearchable': false,
              'mRender': function(data, type, full) {
                 return '<span class="dateDisplay">' + data + '</span>';
             }},

--- a/kickoff/test/views/test_releases.py
+++ b/kickoff/test/views/test_releases.py
@@ -1,6 +1,7 @@
 import datetime
 import random
 import string
+import unittest
 
 import pytz
 
@@ -288,3 +289,68 @@ class TestReleaseView(ViewTest):
         ])
         ret = self.post('/release.html', query_string={'name': 'Thunderbird-2-build2'}, data=data, content_type='application/x-www-form-urlencoded')
         self.assertEquals(ret.status_code, 403)
+
+class TestReleasesListAPI(ViewTest):
+    uri = '/releases/releaseslist'
+    dataTableVersion = '1.9.4'
+
+    def testGetReleases(self):
+        params = {
+            'iDisplayStart': 0,
+            'iDisplayLength': 10,
+            'datatableVersion': self.dataTableVersion,
+            'complete': True,
+            'iSortCol_0': 0,
+            'mDataProp_0': 'name',
+            'sSortDir_0': 'desc',
+            'iColumns': 17
+        }
+
+        ret = self.get(self.uri, query_string=params)
+        self.assertEquals(ret.status_code, 200)
+
+    def testGetReleasesOrderBySubmittedAt(self):
+        params = {
+            'iDisplayStart': 0,
+            'iDisplayLength': 10,
+            'datatableVersion': self.dataTableVersion,
+            'complete': True,
+            'iSortCol_0': 0,
+            'mDataProp_0': 'submittedAt',
+            'sSortDir_0': 'desc',
+            'iColumns': 17
+        }
+
+        ret = self.get(self.uri, query_string=params)
+        self.assertEquals(ret.status_code, 200)
+
+    def testGetReleasesOrderByShippedAt(self):
+        params = {
+            'iDisplayStart': 0,
+            'iDisplayLength': 10,
+            'datatableVersion': self.dataTableVersion,
+            'complete': True,
+            'iSortCol_0': 0,
+            'mDataProp_0': 'shippedAt',
+            'sSortDir_0': 'asc',
+            'iColumns': 17
+        }
+
+        ret = self.get(self.uri, query_string=params)
+        self.assertEquals(ret.status_code, 200)
+
+    def testGetReleasesWithFilter(self):
+        params = {
+            'iDisplayStart': 0,
+            'iDisplayLength': 10,
+            'datatableVersion': self.dataTableVersion,
+            'complete': True,
+            'iSortCol_0': 1,
+            'mDataProp_1': 'name',
+            'sSortDir_0': 'desc',
+            'iColumns': 17,
+            'sSearch': 'irefo'
+        }
+
+        ret = self.get(self.uri, query_string=params)
+        self.assertEquals(ret.status_code, 200)


### PR DESCRIPTION
As reported by Rail search filter stopped working, this PR is to fix it. It is now possible to search by all non-computed string fields.