### PR TITLE
Added new page to edit a release and allow edit a not shipped release

### DIFF
--- a/kickoff/static/kickoff.js
+++ b/kickoff/static/kickoff.js
@@ -294,7 +294,20 @@ function updateDesc(releaseName, id) {
     sendAjaxQuery(releaseName, query);
 }
 
+function releaseIsShippedCheckbox(){
+    if($('#isShipped').is(':checked')){
+            $('.shippedDateInfo').css('display', 'block');
+    }
+    else{
+        $('.shippedDateInfo').css('display', 'none');
+    }
+}
+
 function editRelease() {
     $('#shippedAtDate').datepicker({dateFormat: 'yy/mm/dd'});
     $('#shippedAtTime').mask('00:00:00');
+
+    releaseIsShippedCheckbox();
+
+    $('#isShipped').change(releaseIsShippedCheckbox);
 }

--- a/kickoff/templates/edit_release.html
+++ b/kickoff/templates/edit_release.html
@@ -29,7 +29,30 @@
 		{% endif %}
 
 		<div class="row" style="margin-top: 10px;">
-			<div class="col-sm-4 col-md-4">
+			<div class="col-sm-12 col-md-12 " >
+				{{ form.description.label }}
+				{{ form.description(class="form-control") }}
+			</div>
+		</div>
+
+		<div class="row" style="margin-top: 10px;">
+			<div class="col-sm-2 col-md-2 ">
+				<div class="checkbox">
+					<label style="white-space: nowrap; padding-top: 18px; font-weight: bold;">
+						{{ form.isSecurityDriven }} {{ form.isSecurityDriven.label.text }}
+					</label>
+				</div>
+			</div>
+
+			<div class="col-sm-2 col-md-2 ">
+				<div class="checkbox">
+					<label style="white-space: nowrap; padding-top: 18px; font-weight: bold;">
+						{{ form.isShipped }} {{ form.isShipped.label.text }}
+					</label>
+				</div>
+			</div>
+
+			<div class="col-sm-8 col-md-8 shippedDateInfo" style="display: none;">
 				<label style="white-space: nowrap;">{{form.shippedAtDate.label.text}}</label>
 				<div class="form-inline">
 					<div class="form-group">
@@ -41,28 +64,12 @@
 					</div>
 				</div>
 			</div>
-
-			<div class="col-sm-4 col-md-4 ">
-				<div class="checkbox">
-					<label style="white-space: nowrap; padding-top: 18px; font-weight: bold;">
-						{{ form.isSecurityDriven }} {{ form.isSecurityDriven.label.text }}
-					</label>
-				</div>
-			</div>
-			<div class="col-sm-4 col-md-4">
-			</div>
-		</div>
-
-		<div class="row" style="margin-top: 10px;">
-			<div class="col-sm-12 col-md-12 " >
-				{{ form.description.label }}
-				{{ form.description(class="form-control") }}
-			</div>
 		</div>
 
 		<div class="row" style="margin-top: 10px; margin-bottom: 50px;">
-			<div class="col-sm-12 col-md-12 " >
-				<button type="submit" class="btn btn-default pull-right">Update</button>
+			<div class="col-sm-12 col-md-12" >
+				<button type="submit" style="margin-left: 10px;" class="btn btn-default pull-right">Update</button>
+				<a class="btn btn-default pull-right" href="/releases.html" alt="Cancel">Cancel</a>
 			</div>
 		</div>
 	</div>

--- a/kickoff/views/forms.py
+++ b/kickoff/views/forms.py
@@ -399,20 +399,26 @@ class ReleaseEventsAPIForm(Form):
     group = StringField('Group:', default='other')
 
 class EditReleaseForm(Form):
-    shippedAtDate = DateField('Shipped date', format='%Y/%m/%d', validators=[DataRequired('Shipped Date is required')])
-    shippedAtTime = StringField('', validators=[DataRequired('Shipped Time is required')])
+    shippedAtDate = DateField('Shipped date', format='%Y/%m/%d', validators=[validators.optional(), ])
+    shippedAtTime = StringField('Shipped time')
     isSecurityDriven = BooleanField('Is Security Driven ?')
     description = TextAreaField('Description')
-    
-    def validate_shippedAtDate(form, field):
-        dt = form.shippedAt
+    isShipped = BooleanField('Is Shipped ?')
 
-        if dt > datetime.now():
-            raise ValidationError('Invalid Date')
+    def validate_isShipped(form, field):
+        if form.isShipped.data:
+            dt = form.shippedAt
+
+            if (not dt) or (dt > datetime.now()):
+                raise ValidationError('Invalid Date for Shipped release')
 
     @property
     def shippedAt(self):
-        dt = self.shippedAtDate.data
-        tm = datetime.strptime(self.shippedAtTime.data, '%H:%M:%S').time()
-        dateAndTime = datetime.combine(dt, tm)
+        dateAndTime = None
+
+        if self.shippedAtDate.data:
+            dt = self.shippedAtDate.data
+            tm = datetime.strptime(self.shippedAtTime.data, '%H:%M:%S').time()
+            dateAndTime = datetime.combine(dt, tm)
+
         return dateAndTime

--- a/kickoff/views/releases.py
+++ b/kickoff/views/releases.py
@@ -310,10 +310,14 @@ class EditRelease(MethodView):
         if not release:
             abort(404)
             
-        formRelease = EditReleaseForm(obj = release)
-        formRelease.shippedAtDate.process_data(release._shippedAt)
-        strTime = str(release._shippedAt.time())
-        formRelease.shippedAtTime.data = strTime
+        formRelease = EditReleaseForm(obj = release, isShipped = release._shippedAt is not None)
+
+        notShipped = True
+
+        if release._shippedAt:
+            formRelease.shippedAtDate.process_data(release._shippedAt)
+            strTime = str(release._shippedAt.time())
+            formRelease.shippedAtTime.data = strTime
 
         return render_template('edit_release.html', form=formRelease, release=release)
 
@@ -335,7 +339,13 @@ class EditRelease(MethodView):
             return make_response(render_template('edit_release.html', errors=errors, form=form, release=release), 400)
 
         form.populate_obj(release)
-        release.shippedAt = form.shippedAt
+
+        if form.isShipped.data:
+            release.shippedAt = form.shippedAt
+            release.status = 'postrelease'
+        else:
+            release.shippedAt = None
+            release.status = 'Started'
 
         db.session.add(release)
         db.session.commit()


### PR DESCRIPTION
A new PR was made to edit a release. The new changes are considering the "Shipped!/Not Shipped!" button logic to prevent break them.

If the release is marked as shipped, the shipped date is required.
Non shipped release allow to edit the description and the security driven field.

I thought to enable edit the "shipped releases" only, but I wasn't sure.