### PR TITLE
Added new page to edit a release and allow edit a not shipped release

### DIFF
--- a/kickoff/static/kickoff.js
+++ b/kickoff/static/kickoff.js
@@ -294,7 +294,19 @@ function updateDesc(releaseName, id) {
     sendAjaxQuery(releaseName, query);
 }
 
+function releaseIsShippedCheckbox() {
+    if ($('#isShipped').is(':checked')) {
+        $('.shippedDateInfo').css('display', 'block');
+    } else {
+        $('.shippedDateInfo').css('display', 'none');
+    }
+}
+
 function editRelease() {
     $('#shippedAtDate').datepicker({dateFormat: 'yy/mm/dd'});
     $('#shippedAtTime').mask('00:00:00');
+
+    releaseIsShippedCheckbox();
+
+    $('#isShipped').change(releaseIsShippedCheckbox);
 }

--- a/kickoff/templates/edit_release.html
+++ b/kickoff/templates/edit_release.html
@@ -1,9 +1,6 @@
-<!-- #ex-dev -->
-
 {% extends "base.html" %}
 
 {% block content %}
-
 
 <form method="POST" action="/release/{{ release.name }}/edit_release.html">
 	<div class="container">
@@ -29,7 +26,30 @@
 		{% endif %}
 
 		<div class="row" style="margin-top: 10px;">
-			<div class="col-sm-4 col-md-4">
+			<div class="col-sm-12 col-md-12 " >
+				{{ form.description.label }}
+				{{ form.description(class="form-control") }}
+			</div>
+		</div>
+
+		<div class="row" style="margin-top: 10px;">
+			<div class="col-sm-2 col-md-2 ">
+				<div class="checkbox">
+					<label style="white-space: nowrap; padding-top: 18px; font-weight: bold;">
+						{{ form.isSecurityDriven }} {{ form.isSecurityDriven.label.text }}
+					</label>
+				</div>
+			</div>
+
+			<div class="col-sm-2 col-md-2 ">
+				<div class="checkbox">
+					<label style="white-space: nowrap; padding-top: 18px; font-weight: bold;">
+						{{ form.isShipped }} {{ form.isShipped.label.text }}
+					</label>
+				</div>
+			</div>
+
+			<div class="col-sm-8 col-md-8 shippedDateInfo" style="display: none;">
 				<label style="white-space: nowrap;">{{form.shippedAtDate.label.text}}</label>
 				<div class="form-inline">
 					<div class="form-group">
@@ -37,32 +57,15 @@
 					</div>
 					<div class="form-group">
 						{{ form.shippedAtTime(class="form-control", style="width: 90px;") }}
-
 					</div>
 				</div>
-			</div>
-
-			<div class="col-sm-4 col-md-4 ">
-				<div class="checkbox">
-					<label style="white-space: nowrap; padding-top: 18px; font-weight: bold;">
-						{{ form.isSecurityDriven }} {{ form.isSecurityDriven.label.text }}
-					</label>
-				</div>
-			</div>
-			<div class="col-sm-4 col-md-4">
-			</div>
-		</div>
-
-		<div class="row" style="margin-top: 10px;">
-			<div class="col-sm-12 col-md-12 " >
-				{{ form.description.label }}
-				{{ form.description(class="form-control") }}
 			</div>
 		</div>
 
 		<div class="row" style="margin-top: 10px; margin-bottom: 50px;">
-			<div class="col-sm-12 col-md-12 " >
-				<button type="submit" class="btn btn-default pull-right">Update</button>
+			<div class="col-sm-12 col-md-12" >
+				<button type="submit" style="margin-left: 10px;" class="btn btn-default pull-right">Update</button>
+				<a class="btn btn-default pull-right" href="/releases.html" alt="Cancel">Cancel</a>
 			</div>
 		</div>
 	</div>

--- a/kickoff/test/views/test_editRelease.py
+++ b/kickoff/test/views/test_editRelease.py
@@ -9,16 +9,19 @@ class TestEditRelease(ViewTest):
 		ret = self.get('/release/Firefox-2.0-build1/edit_release.html')
 		self.assertEquals(ret.status_code, 200)
 
+
 	def testGetReleaseWithError(self):
-		ret = self.get('/release/Firefox-1/edit_release.html')
+		ret = self.get('/release/Firefox-1-notfound/edit_release.html')
 		self.assertEquals(ret.status_code, 404)
+
 
 	def testEditRelease(self):
 		release = {
 			'shippedAtDate': '2013/03/03',
 			'shippedAtTime': '14:44:00',
 			'isSecurityDriven': True,
-			'description': 'Edited Release!'
+			'description': 'Edited Release!',
+			'isShipped': 'y'
 		}
 
 		ret = self.post('/release/Firefox-2.0-build1/edit_release.html', data=release)
@@ -34,6 +37,21 @@ class TestEditRelease(ViewTest):
 			dateAndTime = datetime.combine(dt, tm)
 			self.assertEquals(dbRelease._shippedAt, dateAndTime)
 
+
+	def testEditReleaseNotShipped(self):
+		release = {
+			'isSecurityDriven': True,
+			'description': 'Edited Release!'
+		}
+
+		ret = self.post('/release/Firefox-2.0-build1/edit_release.html', data=release)
+
+		with app.test_request_context():
+			dbRelease = FirefoxRelease.query.filter_by(name='Firefox-2.0-build1').first()
+			self.assertEquals(dbRelease.description, 'Edited Release!')
+			self.assertTrue(dbRelease.isSecurityDriven)
+
+
 	def testEditReleaseWithError(self):
 		release = {
 			'shippedAtDate': '2013/99/99',
@@ -44,3 +62,15 @@ class TestEditRelease(ViewTest):
 
 		ret = self.post('/release/Firefox-2.0-build1/edit_release.html', data=release)
 		self.assertEquals(ret.status_code, 400)
+
+
+	def testEditReleaseNotFount(self):
+		release = {
+			'shippedAtDate': '2013/99/99',
+			'shippedAtTime': '99:44:00',
+			'isSecurityDriven': True,
+			'description': 'Edited Release!'
+		}
+
+		ret = self.post('/release/Firefox-2.0-notfound/edit_release.html', data=release)
+		self.assertEquals(ret.status_code, 404)

--- a/kickoff/views/forms.py
+++ b/kickoff/views/forms.py
@@ -400,20 +400,26 @@ class ReleaseEventsAPIForm(Form):
 
 
 class EditReleaseForm(Form):
-    shippedAtDate = DateField('Shipped date', format='%Y/%m/%d', validators=[DataRequired('Shipped Date is required')])
-    shippedAtTime = StringField('', validators=[DataRequired('Shipped Time is required')])
+    shippedAtDate = DateField('Shipped date', format='%Y/%m/%d', validators=[validators.optional(), ])
+    shippedAtTime = StringField('Shipped time')
     isSecurityDriven = BooleanField('Is Security Driven ?')
     description = TextAreaField('Description')
+    isShipped = BooleanField('Is Shipped ?')
 
-    def validate_shippedAtDate(form, field):
-        dt = form.shippedAt
+    def validate_isShipped(form, field):
+        if form.isShipped.data:
+            dt = form.shippedAt
 
-        if dt > datetime.now():
-            raise ValidationError('Invalid Date')
+            if (not dt) or (dt > datetime.now()):
+                raise ValidationError('Invalid Date for Shipped release')
 
     @property
     def shippedAt(self):
-        dt = self.shippedAtDate.data
-        tm = datetime.strptime(self.shippedAtTime.data, '%H:%M:%S').time()
-        dateAndTime = datetime.combine(dt, tm)
+        dateAndTime = None
+
+        if self.shippedAtDate.data:
+            dt = self.shippedAtDate.data
+            tm = datetime.strptime(self.shippedAtTime.data, '%H:%M:%S').time()
+            dateAndTime = datetime.combine(dt, tm)
+
         return dateAndTime

--- a/kickoff/views/releases.py
+++ b/kickoff/views/releases.py
@@ -310,10 +310,12 @@ class EditRelease(MethodView):
         if not release:
             abort(404)
 
-        formRelease = EditReleaseForm(obj=release)
-        formRelease.shippedAtDate.process_data(release._shippedAt)
-        strTime = str(release._shippedAt.time())
-        formRelease.shippedAtTime.data = strTime
+        formRelease = EditReleaseForm(obj=release, isShipped=release._shippedAt is not None)
+
+        if release._shippedAt:
+            formRelease.shippedAtDate.process_data(release._shippedAt)
+            strTime = str(release._shippedAt.time())
+            formRelease.shippedAtTime.data = strTime
 
         return render_template('edit_release.html', form=formRelease, release=release)
 
@@ -334,7 +336,13 @@ class EditRelease(MethodView):
             return make_response(render_template('edit_release.html', errors=errors, form=form, release=release), 400)
 
         form.populate_obj(release)
-        release.shippedAt = form.shippedAt
+
+        if form.isShipped.data:
+            release.shippedAt = form.shippedAt
+            release.status = 'postrelease'
+        else:
+            release.shippedAt = None
+            release.status = 'Started'
 
         db.session.add(release)
         db.session.commit()


### PR DESCRIPTION


A new PR was made to edit a release. The new changes are considering the "Shipped!/Not Shipped!" button logic to prevent break them.

If the release is marked as shipped, the shipped date is required.
Non shipped release allow to edit the description and the security driven field.

I thought to enable edit the "shipped releases" only, but I wasn't sure.
