### PR TITLE
Bring over Balrog fix for docker+virtualbox on Mac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,6 @@ shipitdb:
     - MYSQL_ROOT_PASSWORD=admin
   volumes:
     - .cache/mysql:/var/lib/mysql
+    # Not sure why, but "scripts/run-mysqld.sh" doesn't work here on Mac, but this does.
+    - ./scripts/run-mysqld.sh:/run-mysqld.sh
+  entrypoint: /run-mysqld.sh

--- a/scripts/run-mysqld.sh
+++ b/scripts/run-mysqld.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# From https://github.com/docker-library/mysql/issues/99
+set -e # fail on any error
+
+echo '* Working around permission errors in Docker on Mac locally by making sure that "mysql" uses the same uid and gid as the host volume'
+TARGET_UID=$(stat -c "%u" /var/lib/mysql)
+echo '-- Setting mysql user to use uid '$TARGET_UID
+usermod -o -u $TARGET_UID mysql || true
+TARGET_GID=$(stat -c "%g" /var/lib/mysql)
+echo '-- Setting mysql group to use gid '$TARGET_GID
+groupmod -o -g $TARGET_GID mysql || true
+echo
+echo '* Starting MySQL'
+chown -R mysql:root /var/run/mysqld/
+/entrypoint.sh mysqld --user=mysql --console


### PR DESCRIPTION
shipitdb fails to write to /var/lib/mysql when using docker with virtualbox on Mac, except with this fix that Ben created for Balrog. Apparently the v1.12 release of Docker (~ mid July) will not have the perms issue because it switches to xhyve (from docker-machine via virtualbox). We would be able to revert this change then.