### PR TITLE
Bug 1146863, make sure we don't ignore X.0 releases when X.0.Y are already in the partial list

### DIFF
--- a/kickoff/static/suggestions.js
+++ b/kickoff/static/suggestions.js
@@ -234,7 +234,7 @@ function populatePartial(name, version, previousBuilds, partialElement) {
 
     for (i = 0; i < partialsADIVersion.length; i++) {
 
-        if (partial.indexOf(partialsADIVersion[i]) > -1) {
+        if (partial.indexOf(partialsADIVersion[i]  + 'build') > -1) {
             // We have already this version in the list of partial
             // Go to the next one
             continue;

--- a/kickoff/test/js/tests.js
+++ b/kickoff/test/js/tests.js
@@ -184,16 +184,16 @@ assert.strictEqual($('#partials').val(), "31.0build1,24.4.0build1,24.3.0build1")
 
 
 // Test case to make sure we will take important ADI in a previous release
-allPartialJ='{"release": [{"version": "36.0.4", "ADI": 5000}, {"version": "36.0.3", "ADI": 5000},  {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}]}';
+allPartialJ='{"release": [{"version": "36.0.4", "ADI": 5000}, {"version": "36.0.3", "ADI": 5000},  {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}, {"version": "36.0.2", "ADI": 300}]}';
 allPartial=JSON.parse(allPartialJ);
 
 
-previousBuilds = {"releases/mozilla-release": ["36.0.4build2", "36.0.3build2",  "36.0build2", "35.0build2"]}
+previousBuilds = {"releases/mozilla-release": ["36.0.4build2", "36.0.3build2",  "36.0.2build2", "36.0build2", "35.0build2"]}
 
 partialElement = $('#partials');
 var result = populatePartial("firefox", "37.0", previousBuilds, partialElement);
 assert.ok( result );
-assert.strictEqual($('#partials').val(), "36.0.4build2,36.0.3build2,35.0build2,");
+assert.strictEqual($('#partials').val(), "36.0.4build2,36.0.3build2,35.0build2,36.0build2");
 
 // Test the case we had during the 38 cycle (beta built from m-r)
 allPartialJ='{"release": [{"version": "38.0.3", "ADI": 5000}, {"version": "35.0", "ADI": 3000}, {"version": "36.0", "ADI": 500}]}';


### PR DESCRIPTION
This is like #74 in that we look for versions like 46.0 in 46.0.1 and get a false match. The test adds a new release with low ADI to make sure it's not picked up.